### PR TITLE
fix_levenshtein_import

### DIFF
--- a/human_name_compare/__init__.py
+++ b/human_name_compare/__init__.py
@@ -3,7 +3,7 @@ import unicodedata
 from typing import Optional, List
 
 import gender_guesser.detector as gender
-from Levenshtein._levenshtein import distance
+from Levenshtein import distance
 from nameparser import HumanName
 from nameparser.config import Constants
 


### PR DESCRIPTION
The import  `from Levenshtein._levenshtein import distance` raises an error.
Changing to` from Levenshtein import distance` seems to solve the problem.